### PR TITLE
feat: unify the format of asset notation.

### DIFF
--- a/apps/ui/src/components/Styled/index.tsx
+++ b/apps/ui/src/components/Styled/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 export const StyledCardWrapper = styled.div`
-  width: 360px;
+  width: 400px;
   padding: 24px;
   border-radius: 16px;
   background: ${(props) => props.theme.palette.common.white};

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "husky": "^6.0.0",
-    "lint-staged": "^10.5.4",
     "lerna": "^4.0.0",
+    "lint-staged": "^10.5.4",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.4",
@@ -44,5 +44,6 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  }
+  },
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5144,9 +5144,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001214:
-  version "1.0.30001216"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001216.tgz#47418a082a4f952d14d8964ae739e25efb2060a9"
-  integrity sha512-1uU+ww/n5WCJRwUcc9UH/W6925Se5aNnem/G5QaSDga2HzvjYMs8vRbekGUN/PnTZ7ezTHcxxTEb9fgiMYwH6Q==
+  version "1.0.30001361"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz"
+  integrity sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Unify the format of asset notation according to [Universal Asset Notation](https://github.com/janx/rfcs/blob/universal-asset-notation/rfcs/0000-universal-asset-notation/0000-universal-asset-notation.md). The new display is as follows.

![1](https://user-images.githubusercontent.com/107106858/176614589-6ab752cc-61f4-40e7-b83c-6d4ae2345889.png)
![2](https://user-images.githubusercontent.com/107106858/176614603-337adbbd-7f37-4090-82bc-a5d8ae11eaeb.png)
![4](https://user-images.githubusercontent.com/107106858/176614616-2987ac1d-c18c-4769-abf1-4b6b83fe187a.png)
![5](https://user-images.githubusercontent.com/107106858/176614624-9015c141-1b19-48fa-9ceb-01c501ec17f0.png)
